### PR TITLE
Remove intermediate representation of keyvalue

### DIFF
--- a/foundationdb/examples/simple-index.rs
+++ b/foundationdb/examples/simple-index.rs
@@ -93,7 +93,7 @@ async fn search_user_by_zipcode(
 
     match result_get_index {
         Ok(results) => {
-            for result in results {
+            for result in results.as_ref() {
                 let (zipcode, id): (String, String) = zipcode_index
                     .unpack(result.key())
                     .expect("Unable to unpack value from index");

--- a/foundationdb/src/mapped_key_values.rs
+++ b/foundationdb/src/mapped_key_values.rs
@@ -14,7 +14,7 @@
 //!
 //! More info can be found in the [relevant documentation](https://github.com/apple/foundationdb/wiki/Everything-about-GetMappedRange).
 
-use crate::future::{FdbFutureHandle, FdbKeyValue};
+use crate::future::{FdbFutureHandle, FdbValue};
 use crate::mem::read_unaligned_slice;
 use crate::{error, KeySelector};
 use crate::{FdbError, FdbResult};
@@ -137,12 +137,13 @@ impl FdbMappedKeyValue {
     }
 
     /// retrieves the associated slice of [`FdbKeyValue`]
-    pub fn key_values(&self) -> &[FdbKeyValue] {
+    pub fn key_values<'a>(&self) -> Vec<FdbValue<'a>> {
         unsafe {
-            &*(read_unaligned_slice(
-                self.0.getRange.data as *const FdbKeyValue,
-                self.0.getRange.m_size as usize,
-            ))
+            let raw_slice = read_unaligned_slice(
+                    self.0.getRange.data as *const fdb_sys::FDBKeyValue,
+                    self.0.getRange.m_size as usize,
+            );
+            (*raw_slice).iter().map(|v| (*v).into()).collect()
         }
     }
 }

--- a/foundationdb/src/mem.rs
+++ b/foundationdb/src/mem.rs
@@ -12,10 +12,3 @@ pub(crate) unsafe fn read_unaligned_slice<T>(src: *const T, len: usize) -> *cons
     copy_nonoverlapping(src as *const u8, aligned, layout.size());
     std::slice::from_raw_parts(aligned as *const T, len)
 }
-
-pub(crate) unsafe fn read_unaligned_struct<T>(src: *const T) -> *const T {
-    let layout = Layout::new::<T>();
-    let aligned = std::alloc::alloc(layout);
-    copy_nonoverlapping(src as *const u8, aligned, layout.size());
-    aligned as *const T
-}

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -593,7 +593,7 @@ impl Transaction {
         &'a self,
         opt: RangeOption<'a>,
         snapshot: bool,
-    ) -> impl Stream<Item = FdbResult<FdbValue>> + Unpin + 'a {
+    ) -> impl Stream<Item = FdbResult<FdbValue<'a>>> + Unpin + 'a {
         self.get_ranges(opt, snapshot)
             .map_ok(|values| stream::iter(values.into_iter().map(Ok)))
             .try_flatten()

--- a/foundationdb/tests/range.rs
+++ b/foundationdb/tests/range.rs
@@ -68,17 +68,17 @@ async fn test_get_range_async() -> FdbResult<()> {
         assert!(range.more());
         let len = range.len();
         let mut i = 0;
-        for kv in &range {
+        for kv in range.as_ref() {
             assert!(!kv.key().is_empty());
             assert!(!kv.value().is_empty());
             i += 1;
         }
         assert_eq!(i, len);
 
-        let refs_asc = (&range).into_iter().collect::<Vec<_>>();
+        let refs_asc = range.iter().collect::<Vec<_>>();
         assert_eq!(
             refs_asc,
-            (&range).into_iter().rev().rev().collect::<Vec<_>>()
+            range.iter().rev().rev().collect::<Vec<_>>()
         );
 
         let owned_asc = trx


### PR DESCRIPTION
There is a copy being done to read it from the potentially unaligned memory so it could be more efficient to only copy once instead of every dereference.

This attempts to remove the raw pointer early in the translation and align/own it.