### PR TITLE
Fix alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: ["1.57.0", "stable", "beta", "nightly"]
+        toolchain: ["1.58.1", "stable", "beta", "nightly"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/cron-correctness.yml
+++ b/.github/workflows/cron-correctness.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         parallelism: ["1", "2", "3"]
+        toolchain: ["1.58.1", "stable", "beta", "nightly"]
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: 1
@@ -37,7 +38,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           profile: minimal
 
       - name: Build

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,38 @@
+name: Minimal Supported Rust Version
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+        with:
+          version: "7.1.25"
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+
+      - name: Verify MSRV
+        run: cargo msrv verify
+        working-directory: ./foundationdb
+
+      - name: Find MSRV
+        if: failure()
+        run: cargo msrv
+        working-directory: ./foundationdb

--- a/.github/workflows/pr-correctness.yml
+++ b/.github/workflows/pr-correctness.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         parallelism: ["1", "2", "3"]
+        toolchain: ["1.58.1", "stable", "beta", "nightly"]
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: 1
@@ -35,7 +36,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           profile: minimal
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/foundationdb-rs/foundationdb-rs/ci.yml?branch=main)](https://github.com/foundationdb-rs/foundationdb-rs/actions)
 [![dependency status](https://deps.rs/repo/github/foundationdb-rs/foundationdb-rs/status.svg)](https://deps.rs/repo/github/foundationdb-rs/foundationdb-rs)
 [![Codecov](https://img.shields.io/codecov/c/github/foundationdb-rs/foundationdb-rs)](https://codecov.io/gh/foundationdb-rs/foundationdb-rs)
-![Rustc 1.57+](https://img.shields.io/badge/rustc-1.57+-lightgrey)
+![Rustc 1.58+](https://img.shields.io/badge/rustc-1.58+-lightgrey)
 
 # FoundationDB Rust Client
 
@@ -14,7 +14,7 @@ The repo consists of multiple crates:
 | [**foundationdb-sys**](foundationdb-sys/README.md) | [![Crates.io](https://img.shields.io/crates/v/foundationdb-sys)](https://crates.io/crates/foundationdb-sys) [![foundationdb-sys](https://docs.rs/foundationdb-sys/badge.svg)](https://docs.rs/foundationdb-sys) | C API bindings for FoundationDB                             |
 | **foundationdb-gen**                               | n/a                                                                                                                                                                                                             | Code generator for common options and types of FoundationDB |
 
-The current version requires rustc 1.57+ to work.
+The current version requires rustc 1.58+ to work.
 The previous version (0.3) is still maintained and is available within the 0.3 branch.
 
 You can access the `main` branch documentation [here](https://foundationdb-rs.github.io/foundationdb-rs/foundationdb/index.html).

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
           # Rust part
           cargo-expand
           cargo-edit
+          cargo-msrv
           rust-analyzer
           (rust-bin.stable.latest.default.override {
             extensions = [ "rust-src" ];

--- a/foundationdb-bench/Cargo.toml
+++ b/foundationdb-bench/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Vincent Rouillé <vincent@clikengo.com>",
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 description = """
 Bindings to the C api for FoundationDB

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 description = """
 Bindings to the C api for FoundationDB

--- a/foundationdb-gen/Cargo.toml
+++ b/foundationdb-gen/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 description = """
 Binding generation helper for FoundationDB.

--- a/foundationdb-macros/Cargo.toml
+++ b/foundationdb-macros/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 description = """
 Macro definitions used to maintain the FoundationDB's crate

--- a/foundationdb-sys/Cargo.toml
+++ b/foundationdb-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 description = """
 Bindings to the C api for FoundationDB

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Pierre Zemb <contact@pierrezemb.fr>"
 ]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 description = """
 High level client bindings for FoundationDB.

--- a/foundationdb/README.md
+++ b/foundationdb/README.md
@@ -4,7 +4,7 @@ This is a wrapper library around the FoundationDB (Fdb) C API. It implements fut
 
 ## Prerequisites
 
-* Rust 1.57.0 or more,
+* Rust 1.58.1 or more,
 * FoundationDB's client installed.
 
 ## Platform Support


### PR DESCRIPTION
Fdb Arenas allocate structs not aligned, even though `fdb_c.h` explicitly specifies a 4bytes alignment for most of them (the others using their default alignment, 8bytes in general):
https://github.com/PierreZ/foundationdb-rs/blob/e8463554a2cc5f582842bf6b27aef0db57f00456/foundationdb-sys/include/710/fdb_c.h#L88-L92

These alignment constraints are translated in Rust in bindings.rs by bindgen and exported by `foundationdb_sys`:
https://github.com/PierreZ/foundationdb-rs/blob/e8463554a2cc5f582842bf6b27aef0db57f00456/foundationdb-sys/build.rs#L114-L115

```rs
#[repr(C, packed(4))]
#[derive(Debug, Copy, Clone)]
pub struct key {
    pub key: *const u8,
    pub key_length: ::std::os::raw::c_int,
}
pub type FDBKey = key;
```

And inherited by their "local wrappers":
https://github.com/PierreZ/foundationdb-rs/blob/e8463554a2cc5f582842bf6b27aef0db57f00456/foundationdb/src/fdb_keys.rs#L156-L158

Data is transferred between the fdbserver and foundationdb-rs via pointers which lead to this kind of code:
https://github.com/PierreZ/foundationdb-rs/blob/e8463554a2cc5f582842bf6b27aef0db57f00456/foundationdb/src/fdb_keys.rs#L42-L49

`self.keys` is a C pointer that points to a `FDBKey` potentially misaligned in a Fdb Arena. In the newer versions of Rust `from_raw_parts` panics with debug_assertions on pointer misalignment. Even if we ignore this, the fact that misaligned structs are currently read correctly is probably due to x86 compliance but is still undefined behavior.

In this PR, "local wrappers" are annotated with `packed` instead of `transparent`:
https://github.com/Wonshtrum/foundationdb-rs/blob/c6b198ddef85ca77bab40ea11cda1c08c9d09e35/foundationdb/src/fdb_keys.rs#L157-L159

This explicitly tells Rust that we do not expect these structs to be aligned. This removes the panics on newer versions as these structs are 1byte align (which a pointer will always be) and furthermore, we do not have to rely on x86 to magically accept unaligned structs as misalignment will be explicitly taken care of at machine code generation.

These wrappers are used everywhere in favor of their raw counterparts from `fdb_sys`, and `deref` functions are rewritten using this form:
https://github.com/Wonshtrum/foundationdb-rs/blob/c6b198ddef85ca77bab40ea11cda1c08c9d09e35/foundationdb/src/fdb_keys.rs#L46-L50

> note also the `assert_eq_align!(FdbKey, u8);`