### PR TITLE
Use clang and libc++ to match the fdbserver

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "linker=clang"]

--- a/foundationdb-simulation/build.rs
+++ b/foundationdb-simulation/build.rs
@@ -15,6 +15,8 @@ fn main() {
     let stringified_api_version = format!("{}", api_version);
 
     cc::Build::new()
+        .compiler("clang")
+        .cpp_set_stdlib("c++")
         .cpp(true)
         .define("FDB_API_VERSION", stringified_api_version.as_str())
         .file("src/FDBWrapper.cpp")


### PR DESCRIPTION
The `LD_LIBRARY_PATH` probably lacks the path to `libc++`, so the simulation might crash at runtime saying it could not dynamically load `libc++`. I don't know in what yaml this should be added.